### PR TITLE
Fix for break where index out in get_jaw_position with Francisco Penaloza

### DIFF
--- a/metrics_examples.py
+++ b/metrics_examples.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import os
 
 from complexity.PyComplexityMetric import (
     PyComplexityMetric,
@@ -32,11 +33,17 @@ if __name__ == "__main__":
         plan_metric = cc_obj.CalculateForPlan(None, plan_dict)
         print(f"{cc.__name__} Plan Metric - {plan_metric} {unit}")
         for k, beam in plan_dict["beams"].items():
-            fig, ax = plt.subplots()
-            cpx_beam_cp = cc_obj.CalculateForBeamPerAperture(None, plan_dict, beam)
-            ax.plot(cpx_beam_cp)
-            ax.set_xlabel("Control Point")
-            ax.set_ylabel(f"${unit}$")
-            txt = f"Beam name: {k} - {cc.__name__} per control point"
-            ax.set_title(txt)
-            plt.show()
+            # skip setup fields
+            if beam["TreatmentDeliveryType"] == "TREATMENT" and beam["MU"] > 0:
+                fig = plt.figure(figsize=(6, 6))
+                # create a subplot
+                ax = fig.add_subplot(111)
+                cpx_beam_cp = cc_obj.CalculateForBeamPerAperture(
+                    None, plan_dict, beam
+                )
+                ax.plot(cpx_beam_cp)
+                ax.set_xlabel("Control Point")
+                ax.set_ylabel(f"${unit}$")
+                txt = f"Output - Beam name: {beam['BeamName']} - {cc.__name__}"
+                ax.set_title(txt)
+                plt.show()


### PR DESCRIPTION
We encountered an issue where the index was out of range running on the test data. It appears that the control points only include jaw position sometimes. For this reason we updated the code to take the previous jaw position when available.

Also it appeared to function on a Mac, but not Windows computer.